### PR TITLE
Adding social images to front matter - why isn't this automatic?

### DIFF
--- a/content/posts/20200901-thoughts-on-cyberpunk.md
+++ b/content/posts/20200901-thoughts-on-cyberpunk.md
@@ -9,6 +9,8 @@ tags: ["cyberpunk","fiction"]
 
 cover: "/images/cover-images/cyberpunk.jpg"
 coverAlt: "An athletic looking gaming miniature, with pink hair, standing on a Tim Doyle art piece of Blade Runner"
+images:
+    - "/images/cover-images/cyberpunk.jpg"
 
 slug: "thoughts-on-cyberpunk"
 ---

--- a/content/posts/20200902-drama-familiarity-repetition.md
+++ b/content/posts/20200902-drama-familiarity-repetition.md
@@ -9,6 +9,8 @@ tags: ["drama"]
 
 cover: "/images/cover-images/drama.jpg"
 coverAlt: "A gaming miniature figure standing on top of a picture of Shakespeare"
+images:
+    - "/images/cover-images/drama.jpg"
 
 slug: "drama-familiarity-repetition"
 ---

--- a/content/posts/20200903-emotional-connection-1980s.md
+++ b/content/posts/20200903-emotional-connection-1980s.md
@@ -9,6 +9,8 @@ tags: ["80s","culture"]
 
 cover: "/images/cover-images/eighties.jpg"
 coverAlt: "A gaming miniature figurine standing on a vinyl record of Frankie Goes to Hollywood's 'Two Tribes'"
+images:
+    - "/images/cover-images/eighties.jpg"
 
 slug: "emotional-connection-of-the-1980s"
 ---

--- a/content/posts/20200904-scifi-or-fantasy.md
+++ b/content/posts/20200904-scifi-or-fantasy.md
@@ -9,6 +9,8 @@ tags: ["fiction","scifi"]
 
 cover: "/images/cover-images/sci-fi-fantasy.jpg"
 coverAlt: "A gaming miniature standing between two books, one fantasy and one sci-fi"
+images:
+    - "/images/cover-images/sci-fi-fantasy.jpg"
 
 slug: "science-fiction-or-fantasy"
 ---

--- a/content/posts/20200905-oligarchy-and-corporate-control.md
+++ b/content/posts/20200905-oligarchy-and-corporate-control.md
@@ -9,6 +9,8 @@ tags: ["politics","economics","inequality"]
 
 cover: "/images/cover-images/oligarchy-money.jpg"
 coverAlt: "A gaming miniature with a shield and a gun, standing on Canadian, Chinese, and British banknotes"
+images:
+    - "/images/cover-images/oligarchy-money.jpg"
 
 slug: "oligarchy-or-corporate-control"
 ---

--- a/content/posts/20200906-do-pandemics-in-fiction-still-work.md
+++ b/content/posts/20200906-do-pandemics-in-fiction-still-work.md
@@ -9,6 +9,8 @@ tags: ["covid","fiction"]
 
 cover: "/images/cover-images/pandemic-mask.jpg"
 coverAlt: "A small roleplaying miniature placed on a full-sized facemask"
+images:
+    - "/images/cover-images/pandemic-mask.jpg"
 
 slug: "pandemics-in-fiction"
 ---

--- a/content/posts/20200909-shipwreck-story.md
+++ b/content/posts/20200909-shipwreck-story.md
@@ -9,6 +9,8 @@ tags: ["fiction", "writing", "pirates"]
 
 cover: "/images/cover-images/pirate-story.jpg"
 coverAlt: "A miniature figure waving a gun and a chainsword, in front of a pewter goblet with a squid shaped handle"
+images:
+    - "/images/cover-images/pirate-story.jpg"
 
 slug: shipwreck-story
 ---

--- a/content/posts/20200911-why-taxation-is-good.md
+++ b/content/posts/20200911-why-taxation-is-good.md
@@ -9,6 +9,8 @@ tags: ["politics","economics"]
 
 cover: "/images/cover-images/taxation.jpg"
 coverAlt: "A miniature of a Warhammer 40k Necron standing on a W2 form"
+images:
+    - "/images/cover-images/taxation.jpg"
 
 slug: why-taxation-can-be-good
 ---


### PR DESCRIPTION
According to [Hugo documentation](https://gohugo.io/templates/internal/), this shouldn't be necessary - and the internal template should fall back and find the "cover" image. But it isn't, so setting manually until I can figure that out.